### PR TITLE
Add TOP Jira CSV Export importer, analytics, and Persian report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # lab-agile-planning
+
+Static TOP Jira CSV Export importer and analytics prototype.
+
+## Features
+
+- Fixed import profile: **TOP Jira CSV Export**.
+- Parses UTF-8 BOM Jira CSV exports with duplicate headers without overwriting repeated columns.
+- Stores duplicate-column values as arrays in `rawJson` and normalizes fields for reporting.
+- Builds snapshot analytics, one-click latest-vs-previous comparison, and Persian management reports.
+- Exports the Persian report as Markdown or HTML from `public/index.html`.
+
+## Development
+
+```bash
+npm install
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "lab-agile-planning",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "csv-parse": "^5.5.6"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,1 @@
+{"scripts":{"test":"node --test"},"dependencies":{"csv-parse":"^5.5.6"},"devDependencies":{},"type":"module"}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,27 @@
+<!doctype html><html lang="fa" dir="rtl"><head><meta charset="utf-8"><title>TOP Jira CSV Export Importer</title><style>body{font-family:sans-serif;margin:2rem;line-height:1.6}textarea{width:100%;height:18rem}pre{white-space:pre-wrap;background:#f6f6f6;padding:1rem}label{display:block;margin:.75rem 0}.warn{color:#9a6700}</style></head><body>
+<h1>TOP Jira CSV Export Importer</h1>
+<label>Import profile <select id="profile"><option>TOP Jira CSV Export</option></select></label>
+<label>Sprint name (required when Jira Sprint column is empty) <input id="sprint" placeholder="مثلاً Sprint 24" /></label>
+<label>Jira CSV file <input id="file" type="file" accept=".csv,text/csv" /></label>
+<button id="import">Validate import</button><button id="compare">Compare latest with previous</button><button id="md">Export Persian Markdown</button><button id="html">Export Persian HTML</button>
+<h2>Validation summary</h2><pre id="summary">No file imported yet.</pre>
+<h2>Data quality warnings</h2><pre id="warnings"></pre>
+<h2>Persian report</h2><textarea id="report"></textarea>
+<script type="module">
+import { importTopJiraCsv, compareSnapshots, generatePersianReport, markdownToHtml } from '../src/jiraTopImport.js';
+let snapshots = JSON.parse(localStorage.getItem('topJiraSnapshots')||'[]'), latest, comparison;
+const $=id=>document.getElementById(id);
+$('import').onclick = async()=>{
+  const f=$('file').files[0]; if(!f) return alert('CSV را انتخاب کنید');
+  latest = importTopJiraCsv(await f.text(), { sprintName:$('sprint').value, reportDate:new Date().toISOString() });
+  $('summary').textContent = JSON.stringify({profile:latest.profile,issues:latest.issues.length,columns:latest.headers.length,duplicateHeaders:latest.duplicateHeaders,analytics:latest.analytics}, null, 2);
+  const q=latest.analytics.dataQuality;
+  $('warnings').textContent = [`Missing story points: ${q.missingStoryPoints}`,`Missing stakeholder: ${q.missingStakeholder}`,`Missing due date: ${q.missingDueDate} (due date risk could not be fully calculated when missing)`,`Missing team: ${q.missingTeam}`,`Missing sprint in CSV: ${q.missingSprint}`].join('\n');
+  snapshots.push(latest); localStorage.setItem('topJiraSnapshots', JSON.stringify(snapshots));
+  $('report').value = generatePersianReport(latest);
+};
+$('compare').onclick=()=>{ if(snapshots.length<2) return alert('حداقل دو snapshot لازم است'); latest=snapshots.at(-1); comparison=compareSnapshots(snapshots.at(-2), latest); $('summary').textContent=JSON.stringify(comparison.analytics,null,2); $('report').value=generatePersianReport(latest, comparison); };
+function download(name,type,text){const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([text],{type}));a.download=name;a.click();}
+$('md').onclick=()=>download('persian-jira-report.md','text/markdown;charset=utf-8',$('report').value);
+$('html').onclick=()=>download('persian-jira-report.html','text/html;charset=utf-8',markdownToHtml($('report').value));
+</script></body></html>

--- a/src/jiraTopImport.js
+++ b/src/jiraTopImport.js
@@ -1,0 +1,151 @@
+import { parse } from 'csv-parse/sync';
+
+export const TOP_JIRA_PROFILE = 'TOP Jira CSV Export';
+
+export const STATUS_GROUPS = {
+  backlog: ['Backlog', 'Active Backlog'],
+  readyApproved: ['Approved'],
+  currentSprint: ['Current', 'In Progress', 'Development', 'Development Planned'],
+  carryOver: ['Remain'],
+  blockedAttention: ['Stopped', 'Pending'],
+  reviewUat: ['Review'],
+  doneReleased: ['Released'],
+  rejected: ['Rejected'],
+};
+
+const GROUP_LABELS = {
+  backlog: 'Backlog', readyApproved: 'Ready/Approved', currentSprint: 'Current Sprint',
+  carryOver: 'Carry-over', blockedAttention: 'Blocked/Attention', reviewUat: 'Review/UAT',
+  doneReleased: 'Done/Released', rejected: 'Rejected', other: 'Other'
+};
+
+const col = {
+  summary: 'Summary', key: 'Issue key', id: 'Issue id', type: 'Issue Type', status: 'Status', priority: 'Priority',
+  assignee: 'Assignee', reporter: 'Reporter', creator: 'Creator', created: 'Created', updated: 'Updated',
+  components: 'Component/s', labels: 'Labels', description: 'Description', originalEstimate: 'Original Estimate',
+  remainingEstimate: 'Remaining Estimate', carryOnSprint: 'Custom field (Carry on Sprint)', dueDate: 'Custom field (Due Date (jalali))',
+  letterNumber: 'Custom field (Letter Number)', originalStoryPoints: 'Custom field (Original story points)',
+  requestDate: 'Custom field (Request Date)', riceValue: 'Custom field (Rice Value)', sprint: 'Sprint',
+  contact: 'Custom field (StakeHolder Contact Point)', director: 'Custom field (StakeHolder Director)', vp: 'Custom field (StakeHolder VP)',
+  storyPoints: 'Custom field (Story Points)', team: 'Custom field (Team)', flagged: 'Custom field (Flagged)', comment: 'Comment'
+};
+
+export function parseJiraCsv(csvText) {
+  const text = csvText.charCodeAt(0) === 0xfeff ? csvText.slice(1) : csvText;
+  const rows = parse(text, { bom: true, relax_column_count: true, skip_empty_lines: true });
+  if (!rows.length) return { headers: [], records: [] };
+  const headers = rows[0].map(h => String(h ?? '').trim());
+  const records = rows.slice(1).map(values => rowToRecord(headers, values));
+  return { headers, records };
+}
+
+function rowToRecord(headers, values) {
+  const rawJson = {};
+  headers.forEach((header, i) => {
+    const value = clean(values[i]);
+    if (Object.hasOwn(rawJson, header)) rawJson[header] = Array.isArray(rawJson[header]) ? [...rawJson[header], value] : [rawJson[header], value];
+    else rawJson[header] = value;
+  });
+  return rawJson;
+}
+
+const clean = v => String(v ?? '').trim();
+const values = (raw, name) => raw[name] === undefined ? [] : (Array.isArray(raw[name]) ? raw[name] : [raw[name]]);
+const first = (raw, name) => values(raw, name).find(v => clean(v)) || '';
+const nonEmpty = (raw, name) => values(raw, name).map(clean).filter(Boolean);
+const num = v => { const n = Number(String(v ?? '').replace(/,/g, '')); return Number.isFinite(n) ? n : null; };
+const hours = seconds => seconds == null ? 0 : seconds / 3600;
+
+export function normalizeIssue(raw) {
+  const components = nonEmpty(raw, col.components);
+  const teamField = first(raw, col.team);
+  const story = first(raw, col.storyPoints) || first(raw, col.originalStoryPoints);
+  const originalEstimateSeconds = num(first(raw, col.originalEstimate));
+  const remainingEstimateSeconds = num(first(raw, col.remainingEstimate));
+  const comments = nonEmpty(raw, col.comment);
+  return {
+    issueKey: first(raw, col.key), issueId: first(raw, col.id), title: first(raw, col.summary), issueType: first(raw, col.type),
+    status: first(raw, col.status), statusGroup: classifyStatus(first(raw, col.status)), priority: first(raw, col.priority),
+    assignee: first(raw, col.assignee), reporter: first(raw, col.reporter), creator: first(raw, col.creator),
+    createdAtJira: first(raw, col.created), updatedAtJira: first(raw, col.updated), components,
+    team: teamField || components.join(', '), teamSource: teamField ? 'Custom field (Team)' : 'Component/s',
+    labels: first(raw, col.labels), description: first(raw, col.description), stakeholderDeputy: first(raw, col.vp),
+    stakeholderDirector: nonEmpty(raw, col.director), stakeholderContactPoint: nonEmpty(raw, col.contact),
+    storyPoints: num(story), storyPointSource: first(raw, col.storyPoints) ? 'Story Points' : (first(raw, col.originalStoryPoints) ? 'Original story points' : ''),
+    originalEstimateSeconds, remainingEstimateSeconds, estimateHours: hours(originalEstimateSeconds || remainingEstimateSeconds),
+    riceValue: num(first(raw, col.riceValue)), letterNumber: first(raw, col.letterNumber), requestDateJalali: first(raw, col.requestDate),
+    dueDateJalali: first(raw, col.dueDate), sprint: first(raw, col.sprint), isFlagged: Boolean(first(raw, col.flagged)), blockerReason: first(raw, col.flagged),
+    comments, latestComment: comments.at(-1) || '', rawJson: raw
+  };
+}
+
+export function importTopJiraCsv(csvText, { sprintName, reportDate = new Date().toISOString() } = {}) {
+  const { headers, records } = parseJiraCsv(csvText);
+  const duplicateHeaders = headers.filter((h, i) => h && headers.indexOf(h) !== i);
+  const issues = records.map(normalizeIssue).filter(i => i.issueKey);
+  return { profile: TOP_JIRA_PROFILE, sprintName: sprintName || '', reportDate, headers, duplicateHeaders: [...new Set(duplicateHeaders)], issues, analytics: snapshotAnalytics(issues, sprintName) };
+}
+
+export function classifyStatus(status) {
+  for (const [group, statuses] of Object.entries(STATUS_GROUPS)) if (statuses.includes(status)) return group;
+  return 'other';
+}
+
+function inc(obj, key, by = 1) { obj[key || 'نامشخص'] = (obj[key || 'نامشخص'] || 0) + by; }
+export function snapshotAnalytics(issues, sprintName = '') {
+  const a = { totalIssues: issues.length, byStatus: {}, byStatusGroup: {}, byTeam: {}, byStakeholderVp: {}, byPriority: {}, byIssueType: {},
+    flaggedCount: 0, stoppedCount: 0, pendingCount: 0, remainCount: 0, currentSprintCount: 0, reviewCount: 0, releasedCount: 0,
+    estimateHoursByTeam: {}, storyPointsByTeam: {}, dataQuality: { missingStoryPoints: 0, missingStakeholder: 0, missingDueDate: 0, missingTeam: 0, missingSprint: 0, sprintNameRequired: !sprintName } };
+  for (const i of issues) {
+    inc(a.byStatus, i.status); inc(a.byStatusGroup, GROUP_LABELS[i.statusGroup]); inc(a.byTeam, i.team); inc(a.byStakeholderVp, i.stakeholderDeputy); inc(a.byPriority, i.priority); inc(a.byIssueType, i.issueType);
+    if (i.isFlagged) a.flaggedCount++; if (i.status === 'Stopped') a.stoppedCount++; if (i.status === 'Pending') a.pendingCount++; if (i.status === 'Remain') a.remainCount++; if (i.statusGroup === 'currentSprint') a.currentSprintCount++; if (i.status === 'Review') a.reviewCount++; if (i.status === 'Released') a.releasedCount++;
+    if (i.storyPoints == null) { a.dataQuality.missingStoryPoints++; inc(a.estimateHoursByTeam, i.team, i.estimateHours); } else inc(a.storyPointsByTeam, i.team, i.storyPoints);
+    if (!i.stakeholderDeputy) a.dataQuality.missingStakeholder++; if (!i.dueDateJalali) a.dataQuality.missingDueDate++; if (!i.team) a.dataQuality.missingTeam++; if (!i.sprint) a.dataQuality.missingSprint++;
+  }
+  return a;
+}
+
+export function compareSnapshots(previous, current) {
+  const prev = new Map(previous.issues.map(i => [i.issueKey, i]));
+  const cur = new Map(current.issues.map(i => [i.issueKey, i]));
+  const changes = [];
+  for (const [key, i] of cur) {
+    const p = prev.get(key); if (!p) { changes.push(ch('ADDED', key)); continue; }
+    cmp(changes, key, 'STATUS_CHANGED', p.status, i.status); cmp(changes, key, 'PRIORITY_CHANGED', p.priority, i.priority);
+    cmp(changes, key, 'COMPONENT_CHANGED', p.components.join('|'), i.components.join('|')); cmp(changes, key, 'TEAM_CHANGED', p.team, i.team);
+    cmp(changes, key, 'STAKEHOLDER_VP_CHANGED', p.stakeholderDeputy, i.stakeholderDeputy); cmp(changes, key, 'STORY_POINTS_CHANGED', p.storyPoints, i.storyPoints);
+    cmp(changes, key, 'ORIGINAL_ESTIMATE_CHANGED', p.originalEstimateSeconds, i.originalEstimateSeconds); cmp(changes, key, 'REMAINING_ESTIMATE_CHANGED', p.remainingEstimateSeconds, i.remainingEstimateSeconds); cmp(changes, key, 'FLAGGED_CHANGED', p.isFlagged, i.isFlagged);
+    if ((i.comments?.length || 0) > (p.comments?.length || 0)) changes.push(ch('COMMENT_ADDED', key));
+    movement(changes, key, p, i);
+  }
+  for (const key of prev.keys()) if (!cur.has(key)) changes.push(ch('REMOVED', key));
+  return { changes, analytics: comparisonAnalytics(changes, previous, current) };
+}
+const ch = (type, issueKey) => ({ type, issueKey });
+const cmp = (arr, key, type, a, b) => { if ((a ?? '') !== (b ?? '')) arr.push(ch(type, key)); };
+function movement(arr, key, p, i) {
+  const ps = p.statusGroup, cs = i.statusGroup;
+  if (cs === 'currentSprint' && ps !== cs) arr.push(ch('MOVED_TO_CURRENT', key));
+  if (i.status === 'Remain' && p.status !== 'Remain') arr.push(ch('MOVED_TO_REMAIN', key));
+  if (cs === 'blockedAttention' && ps !== cs) arr.push(ch('MOVED_TO_STOPPED_OR_PENDING', key));
+  if (cs === 'reviewUat' && ps !== cs) arr.push(ch('MOVED_TO_REVIEW', key));
+  if (cs === 'doneReleased' && ps !== cs) arr.push(ch('MOVED_TO_RELEASED', key));
+  if (ps === 'currentSprint' && cs !== 'currentSprint') arr.push(ch('MOVED_OUT_OF_CURRENT', key));
+  if (i.status === 'Remain') arr.push(ch('CARRY_OVER', key));
+  if ((i.storyPoints || 0) > (p.storyPoints || 0) || (i.originalEstimateSeconds || 0) > (p.originalEstimateSeconds || 0)) arr.push(ch('SCOPE_INCREASE', key));
+  if ((i.storyPoints || 0) < (p.storyPoints || 0) || (i.originalEstimateSeconds || 0) < (p.originalEstimateSeconds || 0)) arr.push(ch('SCOPE_DECREASE', key));
+}
+function count(changes, type) { return changes.filter(c => c.type === type).length; }
+export function comparisonAnalytics(changes, previous, current) {
+  const changedIssues = new Set(changes.map(c => c.issueKey)).size;
+  return { addedIssueCount: count(changes, 'ADDED'), removedIssueCount: count(changes, 'REMOVED'), statusChangedCount: count(changes, 'STATUS_CHANGED'), movedToCurrentCount: count(changes, 'MOVED_TO_CURRENT'), movedToRemainCount: count(changes, 'MOVED_TO_REMAIN'), movedToStoppedOrPendingCount: count(changes, 'MOVED_TO_STOPPED_OR_PENDING'), movedToReviewCount: count(changes, 'MOVED_TO_REVIEW'), movedToReleasedCount: count(changes, 'MOVED_TO_RELEASED'), movedOutOfCurrentCount: count(changes, 'MOVED_OUT_OF_CURRENT'), priorityChangedCount: count(changes, 'PRIORITY_CHANGED'), stakeholderChangedCount: count(changes, 'STAKEHOLDER_VP_CHANGED'), componentTeamChangedCount: count(changes, 'COMPONENT_CHANGED') + count(changes, 'TEAM_CHANGED'), flaggedChangedCount: count(changes, 'FLAGGED_CHANGED'), estimateDelta: current.issues.reduce((s, i) => s + (i.originalEstimateSeconds || 0), 0) - previous.issues.reduce((s, i) => s + (i.originalEstimateSeconds || 0), 0), scopeChurnPercentage: pct(changedIssues, current.issues.length), carryOverPercentage: pct(current.analytics.remainCount, current.issues.length), blockedAttentionPercentage: pct(current.analytics.stoppedCount + current.analytics.pendingCount + current.analytics.flaggedCount, current.issues.length) };
+}
+const pct = (a, b) => b ? Math.round((a / b) * 1000) / 10 : 0;
+
+export function generatePersianReport(snapshot, comparison) {
+  const a = snapshot.analytics, q = a.dataQuality, c = comparison?.analytics;
+  const dq = `| شاخص | تعداد |\n|---|---:|\n| بدون Story Point | ${q.missingStoryPoints} |\n| بدون ذی‌نفع/معاونت | ${q.missingStakeholder} |\n| بدون Due Date | ${q.missingDueDate} |\n| بدون تیم | ${q.missingTeam} |\n| بدون Sprint در فایل | ${q.missingSprint} |`;
+  return `# گزارش مدیریتی اسپرینت ${snapshot.sprintName || 'نامشخص'}\n\n## 1. خلاصه مدیریتی\nواقعیت: تعداد کل آیتم‌ها ${a.totalIssues} است. Current برابر ${a.currentSprintCount}، Remain برابر ${a.remainCount}، Stopped/Pending/Impediment برابر ${a.stoppedCount + a.pendingCount + a.flaggedCount} و Released برابر ${a.releasedCount} است.\n\n## 2. کیفیت داده گزارش\n${dq}\n\nتحلیل: ${q.missingDueDate ? 'به دلیل نبود Due Date برای بخشی از داده‌ها، ریسک موعد تحویل به طور کامل قابل محاسبه نیست.' : 'داده Due Date برای محاسبه ریسک موجود است.'} ${q.sprintNameRequired ? 'Sprint در فایل خالی است و نام اسپرینت باید هنگام آپلود وارد شود.' : ''}\n\n## 3. تغییرات کلیدی نسبت به گزارش قبلی\n${c ? `Added: ${c.addedIssueCount}، Removed: ${c.removedIssueCount}، Status changed: ${c.statusChangedCount}، Moved to Current: ${c.movedToCurrentCount}، Moved to Remain: ${c.movedToRemainCount}، Moved to Released: ${c.movedToReleasedCount}.` : 'گزارش قبلی برای مقایسه ثبت نشده است.'}\n\n## 4. تحلیل وضعیت کلی آیتم‌ها\n${table(a.byStatusGroup)}\n\n## 5. تحلیل تیم‌ها / کامپوننت‌ها\n${table(a.byTeam)}\n\n## 6. تحلیل معاونت‌ها و ذی‌نفعان\n${table(a.byStakeholderVp)}\n\n## 7. تحلیل Scope و تغییرات برنامه اسپرینت\n${c ? `Scope churn برابر ${c.scopeChurnPercentage}% و تغییر تخمین برابر ${Math.round(c.estimateDelta / 3600)} ساعت است.` : 'برای محاسبه Scope churn نیاز به snapshot قبلی است.'}\n\n## 8. تحلیل آیتم‌های Current\nتعداد آیتم‌های Current/In Progress/Development برابر ${a.currentSprintCount} است.\n\n## 9. تحلیل آیتم‌های Remain و Carry-over\nتعداد Remain برابر ${a.remainCount} است${c ? ` و carry-over برابر ${c.carryOverPercentage}% است.` : '.'}\n\n## 10. تحلیل آیتم‌های Stopped / Pending / Impediment\nStopped: ${a.stoppedCount}، Pending: ${a.pendingCount}، Flagged/Impediment: ${a.flaggedCount}.\n\n## 11. تحلیل آیتم‌های Review و Released\nReview: ${a.reviewCount}، Released: ${a.releasedCount}.\n\n## 12. آیتم‌های دارای تغییر مهم\n${comparison ? comparison.changes.slice(0, 50).map(x => `- ${x.issueKey}: ${x.type}`).join('\n') : 'بدون مقایسه.'}\n\n## 13. ریسک‌ها و موارد نیازمند تصمیم مدیریتی\n- تصمیم درباره آیتم‌های Stopped/Pending/Flagged: ${a.stoppedCount + a.pendingCount + a.flaggedCount} مورد.\n- تکمیل داده‌های ناقص Story Point یا استفاده شفاف از ساعت تخمینی: ${q.missingStoryPoints} مورد.\n- تکمیل Due Date برای محاسبه ریسک زمان‌بندی: ${q.missingDueDate} مورد.\n\n## 14. پیشنهادهای عملی برای جلسه Sprint Planning\n- ظرفیت تیم‌ها بر اساس Story Point موجود و در صورت نبود آن با برچسب «ساعت تخمینی» بررسی شود.\n- آیتم‌های Remain و Flagged پیش از پذیرش Scope جدید تعیین تکلیف شوند.\n- مالکیت آیتم‌های بدون معاونت/ذی‌نفع مشخص شود.`;
+}
+function table(obj) { return '| عنوان | تعداد |\n|---|---:|\n' + Object.entries(obj).map(([k, v]) => `| ${k} | ${Math.round(v * 10) / 10} |`).join('\n'); }
+export function markdownToHtml(md) { return md.replace(/^# (.*)$/gm, '<h1>$1</h1>').replace(/^## (.*)$/gm, '<h2>$1</h2>').replace(/\n/g, '<br>'); }

--- a/test/jiraTopImport.test.js
+++ b/test/jiraTopImport.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { importTopJiraCsv, compareSnapshots, generatePersianReport } from '../src/jiraTopImport.js';
+
+const csv = '\ufeffIssue key,Summary,Issue Type,Status,Priority,Component/s,Component/s,Custom field (Team),Custom field (StakeHolder VP),Custom field (StakeHolder Director),Custom field (StakeHolder Director),Custom field (Story Points),Custom field (Original story points),Original Estimate,Remaining Estimate,Custom field (Flagged),Comment,Comment,Custom field (Due Date (jalali)),Sprint\n' +
+'TOP-1,Login,Story,Current,High,Core,API,,VP1,Dir1,Dir2,,5,7200,3600,Blocked,old,new,,\n' +
+'TOP-2,Search,Bug,Stopped,Low,Search,,,VP2,,,,,3600,,Reason,,,,';
+
+test('imports BOM CSV with duplicate headers and normalized fallback fields', () => {
+  const snap = importTopJiraCsv(csv, { sprintName: 'Sprint 1', reportDate: '2026-06-19' });
+  assert.equal(snap.headers.length, 20);
+  assert.deepEqual(snap.duplicateHeaders.sort(), ['Comment','Component/s','Custom field (StakeHolder Director)'].sort());
+  assert.deepEqual(snap.issues[0].rawJson['Component/s'], ['Core','API']);
+  assert.equal(snap.issues[0].team, 'Core, API');
+  assert.equal(snap.issues[0].storyPoints, 5);
+  assert.equal(snap.issues[0].isFlagged, true);
+  assert.equal(snap.issues[0].latestComment, 'new');
+  assert.equal(snap.analytics.currentSprintCount, 1);
+  assert.equal(snap.analytics.stoppedCount, 1);
+  assert.equal(snap.analytics.dataQuality.missingDueDate, 2);
+});
+
+test('compares snapshots using issue key and detects movements', () => {
+  const prev = importTopJiraCsv(csv.replace('Current','Backlog'), { sprintName: 'Sprint 1' });
+  const cur = importTopJiraCsv(csv, { sprintName: 'Sprint 1' });
+  const diff = compareSnapshots(prev, cur);
+  assert.ok(diff.changes.some(c => c.issueKey === 'TOP-1' && c.type === 'MOVED_TO_CURRENT'));
+  assert.equal(diff.analytics.statusChangedCount, 1);
+});
+
+test('generates Persian report with missing due date warning', () => {
+  const snap = importTopJiraCsv(csv, { sprintName: 'Sprint 1' });
+  const report = generatePersianReport(snap);
+  assert.match(report, /خلاصه مدیریتی/);
+  assert.match(report, /ریسک موعد تحویل/);
+});


### PR DESCRIPTION
### Motivation
- Support the real Jira CSV export format with UTF-8 BOM and duplicate column names without losing or overwriting repeated columns. 
- Provide normalized fields and sensible fallbacks (team ← components, story points ← original story points ← estimate hours) so analytics and comparisons work even with incomplete Jira exports. 
- Produce management-ready Persian reports and a lightweight UI to validate imports, review data quality warnings, and export reports. 

### Description
- Add a parser and importer implementing a fixed profile `TOP Jira CSV Export` with BOM-safe CSV parsing, duplicate-header preservation (store repeated columns as arrays in `rawJson`), and `normalizeIssue` that extracts the mapped fields and fallbacks (components, team, story points, estimates, stakeholders, comments, sprint, flags, dates). 
- Implement status group mapping (`STATUS_GROUPS`) and `classifyStatus`, snapshot analytics (`snapshotAnalytics`) for counts, estimate/story-point aggregation, and data quality metrics. 
- Implement snapshot comparison (`compareSnapshots`) keyed by `Issue key` to detect ADDED/REMOVED, STATUS_CHANGED, PRIORITY_CHANGED, COMPONENT/TEAM/STAKEHOLDER/ESTIMATE/FLAG changes, comment additions, movement events, scope churn and estimate deltas. 
- Add Persian report generator `generatePersianReport` with the requested sections and a `markdownToHtml` exporter, plus a small static UI (`public/index.html`) to validate files, show warnings, compare latest vs previous snapshot, and export Markdown/HTML. 
- Files added: `src/jiraTopImport.js`, `public/index.html`, `test/jiraTopImport.test.js`, `package.json`, `package-lock.json`, and updated `README.md`.

### Testing
- Ran the test suite with `npm test` and all tests passed (3 tests, 0 failures). 
- Tests cover BOM CSV parsing with duplicate headers preserved, normalized fallback behavior (team/component and story point fallbacks), movement detection in `compareSnapshots`, and Persian report inclusion of missing-due-date warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35599dbf548321ac2f4efe238be5ea)